### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "doctrine/orm": "~2.4",
         "friendsofphp/php-cs-fixer": "~1.6",
-        "phpunit/phpunit": "^4.8.10||^5.0"
+        "phpunit/phpunit": "^4.8.35||^5.7"
     },
     "suggest": {
         "doctrine/orm": "For using with the Doctrine ORM"

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -3,8 +3,9 @@
 namespace Jsor\Doctrine\PostGIS;
 
 use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractTestCase extends TestCase
 {
     protected function _registerTypes()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.