### PR TITLE
`primary` is not a valid option for columns

### DIFF
--- a/src/Event/DBALSchemaEventSubscriber.php
+++ b/src/Event/DBALSchemaEventSubscriber.php
@@ -306,7 +306,6 @@ class DBALSchemaEventSubscriber implements EventSubscriber
         $options = array(
             'notnull' => (bool) $tableColumn['isnotnull'],
             'default' => $default,
-            'primary' => (bool) ($tableColumn['pri'] == 't'),
             'comment' => isset($tableColumn['comment']) ? $tableColumn['comment'] : null,
         );
 


### PR DESCRIPTION
Columns don't have a `primary` property. As such, DBAL >= 2.7 throw the following deprecation error:

```
The "primary" column option is not supported, setting it is deprecated and will cause an error in Doctrine 3.0
```