### PR TITLE
PHP8 support for 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.6 || ^7.0 || ^8.0",
         "doctrine/dbal": "^2.4"
     },
     "require-dev": {


### PR DESCRIPTION
Hello,

Following #49 and #48, I needed to get this running on PHP8 for a project. 
I'm currently testing it, 1.x seems to be running fine with PHP8 - since it is the only released version for now, I propose to loosen up the `composer.json` constraint here.
