### PR TITLE
Fixed POINT notation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ to retain as much information as possible (like SRID's). Read more in the
 
 ```php
 $entity = new MyEntity(
-    point: 'POINT(37.4220761 -122.0845187)',
+    point: 'POINT(-122.0845187 37.4220761)',
     point4D: 'POINT(1 2 3 4)',
-    pointWithSRID: 'SRID=3785;POINT(37.4220761 -122.0845187)',
+    pointWithSRID: 'SRID=3785;POINT(-122.0845187 37.4220761)',
 );
 ```
 


### PR DESCRIPTION
This pull request updates the README file to correct the ordering of longitude and latitude values in the POINT notation examples - the current documentation uses the incorrect format `POINT(latitude longitude)`. The standard format for geographic coordinates in PostGIS is `POINT(longitude latitude)`.

In spatial databases like PostGIS, the correct order is longitude followed by latitude. Mixing these up can lead to confusing results, like a European city appearing in Africa on your map.