### PR TITLE
Fix spatial metadata resolution for custom GeometryType subclasses

### DIFF
--- a/src/Schema/SchemaManager.php
+++ b/src/Schema/SchemaManager.php
@@ -232,13 +232,15 @@ final class SchemaManager extends PostgreSQLSchemaManager
 
     protected function resolveSpatialColumnInfo(Column $column, string $tableName): void
     {
-        if (!$column->getType() instanceof PostGISType) {
+        $type = $column->getType();
+        
+        if (!$type instanceof PostGISType) {
             return;
         }
 
-        $info = match ($column->getType()::class) {
-            GeometryType::class => $this->getGeometrySpatialColumnInfo($tableName, $column->getName()),
-            GeographyType::class => $this->getGeographySpatialColumnInfo($tableName, $column->getName()),
+        $info = match (true) {
+            $type instanceof GeometryType => $this->getGeometrySpatialColumnInfo($tableName, $column->getName()),
+            $type instanceof GeographyType => $this->getGeographySpatialColumnInfo($tableName, $column->getName()),
             default => null,
         };
 
@@ -253,7 +255,7 @@ final class SchemaManager extends PostgreSQLSchemaManager
         }
 
         $column
-            ->setType(PostGISType::getType(Type::lookupName($column->getType())))
+            ->setType(PostGISType::getType(Type::lookupName($type)))
             ->setDefault($default)
             ->setPlatformOption('geometry_type', $info['type'])
             ->setPlatformOption('srid', $info['srid'])


### PR DESCRIPTION
When using custom Doctrine spatial types extending `GeometryType` or `GeographyType`, the SchemaManager fails to resolve PostGIS metadata (`geometry_type`, `srid`) from `geometry_columns` / `geography_columns`.

The current implementation compares exact class names:

```php
match ($column->getType()::class)
```
which does not work for subclasses.

Example:
```php
final class GeoPathType extends GeometryType
```

In this case, the match falls into default => null and spatial metadata is never restored on introspected columns.

Consequences:

endless Doctrine migration diffs
columns constantly detected as GEOMETRY,0
invalid schema comparisons for custom spatial types

This patch replaces strict class matching with instanceof to correctly support subclasses of GeometryType and GeographyType.